### PR TITLE
Add Typinator Sets formula

### DIFF
--- a/websharks-typinator-sets.rb
+++ b/websharks-typinator-sets.rb
@@ -4,7 +4,6 @@ class WebsharksTypinatorSets < Formula
   homepage "https://github.com/websharks/typinator-sets"
   url "https://github.com/websharks/typinator-sets.git", :branch => "master"
 
-  depends_on "terminal-notifier" => :recommended
   option "with-local", "Symlinks based on local copy of ~/Projects/typinator-sets"
 
   def install
@@ -20,11 +19,6 @@ class WebsharksTypinatorSets < Formula
         install_from_dir = "#{local_repo_dir}"
       end # Only if directory exists.
     end # Use local repo.
-
-    FileUtils.rm_f "#{script_libraries_dir}/websharks"
-    FileUtils.rm_f "#{typinator_scripts_dir1}/runOSA"
-    FileUtils.rm_f "#{typinator_scripts_dir2}/runOSA"
-
 
     if File.directory? "#{typinator_sets_dir}"
       FileUtils.rm_f "#{typinator_sets_dir}/WebSharks-Abbreviations-Jason.tyset"

--- a/websharks-typinator-sets.rb
+++ b/websharks-typinator-sets.rb
@@ -1,0 +1,43 @@
+require "formula"
+
+class WebsharksTypinatorSets < Formula
+  homepage "https://github.com/websharks/typinator-sets"
+  url "https://github.com/websharks/typinator-sets.git", :branch => "master"
+
+  depends_on "terminal-notifier" => :recommended
+  option "with-local", "Symlinks based on local copy of ~/Projects/typinator-sets"
+
+  def install
+    prefix.install Dir["*"] # Copy all files.
+
+    local_repo_dir = File.expand_path("~/Projects/typinator-sets")
+    typinator_sets_dir = File.expand_path("~/Library/Application Support/Typinator/Sets")
+
+    install_from_dir = "#{prefix}" # Default behavhior.
+
+    if build.with? "local" # From local repo?
+      if File.directory? "#{local_repo_dir}"
+        install_from_dir = "#{local_repo_dir}"
+      end # Only if directory exists.
+    end # Use local repo.
+
+    FileUtils.rm_f "#{script_libraries_dir}/websharks"
+    FileUtils.rm_f "#{typinator_scripts_dir1}/runOSA"
+    FileUtils.rm_f "#{typinator_scripts_dir2}/runOSA"
+
+
+    if File.directory? "#{typinator_sets_dir}"
+      FileUtils.rm_f "#{typinator_sets_dir}/WebSharks-Abbreviations-Jason.tyset"
+      FileUtils.ln_s "#{install_from_dir}/WebSharks-Abbreviations-Jason.tyset", "#{typinator_sets_dir}/WebSharks-Abbreviations-Jason.tyset"
+    end
+
+    if File.directory? "#{typinator_sets_dir}"
+      FileUtils.rm_f "#{typinator_sets_dir}/WebSharks-Abbreviations-Raam.tyset"
+      FileUtils.ln_s "#{install_from_dir}/WebSharks-Abbreviations-Raam.tyset", "#{typinator_sets_dir}/WebSharks-Abbreviations-Raam.tyset"
+    end
+
+  end
+
+  test do
+  end
+end


### PR DESCRIPTION
@jaswsinc I think I got this script right (my first homebrew formula), but if not please let me know. 

I tried to test it locally with Homebrew, but I must be missing something because I couldn't get Homebrew to detect this `.rb` script when I tried copying it manually to `/usr/local/Library/Taps/websharks/homebrew-formulas/`. 

```
$ brew options websharks-typinator-sets
Error: No available formula for websharks-typinator-sets
```

Also, as I'm typing the message for the Pull Request, I suddenly realized that making the `typinator-sets/` repo private probably means Homebrew won't be able to pull anything from it... hmm. I guess we could always checkout the latest `typinator-sets` repo locally and use the `with-local` option, right?
